### PR TITLE
Updated package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "anymatch": "^2.0.0",
     "async-each": "^1.0.1",
     "braces": "^2.3.2",
-    "glob-parent": "^3.1.0",
+    "glob-parent": "3.0.0",
     "inherits": "^2.0.3",
     "is-binary-path": "^1.0.0",
     "is-glob": "^4.0.0",


### PR DESCRIPTION
glob-parent was flagged as of this morning with high severity security risk. The recommendation is to downgrade to 3.0.0, 2.0.0, or 1.0.0.